### PR TITLE
refs support valid css class names as well

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const consoleWarn = console.warn.bind(console) // eslint-disable-line no-console
 const parentRegExp = /&/g
-const refRegExp = /\$(\w+)/g
+const refRegExp = /\$(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)/g
 
 /**
  * Convert nested rules to separate, remove them from original styles.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const consoleWarn = console.warn.bind(console) // eslint-disable-line no-console
 const parentRegExp = /&/g
-const refRegExp = /\$(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)/g
+const refRegExp = /\$([\w-]+)/g
 
 /**
  * Convert nested rules to separate, remove them from original styles.

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -398,50 +398,34 @@ describe('jss-nested', () => {
       sheet = jss.createStyleSheet({
         a: {
           float: 'left',
-          '& $b': {float: 'left'}
+          '& $b': {float: 'left'},
+          '& $b-warn': {float: 'right'}
         },
         b: {
           color: 'red'
+        },
+        'b-warn': {
+          color: 'orange'
         }
       })
     })
 
     it('should generate correct CSS', () => {
       expect(sheet.toString()).to.be(
-        '.a-2101561448 {\n' +
+        '.a-1261267506 {\n' +
         '  float: left;\n' +
         '}\n' +
-        '.a-2101561448 .b-3645560457 {\n' +
+        '.a-1261267506 .b-3645560457 {\n' +
         '  float: left;\n' +
+        '}\n' +
+        '.a-1261267506 .b-warn-1549041947 {\n' +
+        '  float: right;\n' +
         '}\n' +
         '.b-3645560457 {\n' +
         '  color: red;\n' +
-        '}'
-      )
-    })
-  })
-
-  describe('local refs representing valid css class names', () => {
-    let sheet
-
-    beforeEach(() => {
-      sheet = jss.createStyleSheet({
-        a: {
-          '& $b-attention': {float: 'left'}
-        },
-        'b-attention': {
-          color: 'red'
-        }
-      })
-    })
-
-    it('should generate correct CSS', () => {
-      expect(sheet.toString()).to.be(
-        '.a-2802939882 .b-attention-3645560457 {\n' +
-        '  float: left;\n' +
         '}\n' +
-        '.b-attention-3645560457 {\n' +
-        '  color: red;\n' +
+        '.b-warn-1549041947 {\n' +
+        '  color: orange;\n' +
         '}'
       )
     })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -421,6 +421,32 @@ describe('jss-nested', () => {
     })
   })
 
+  describe('local refs representing valid css class names', () => {
+    let sheet
+
+    beforeEach(() => {
+      sheet = jss.createStyleSheet({
+        a: {
+          '& $b-attention': {float: 'left'}
+        },
+        'b-attention': {
+          color: 'red'
+        }
+      })
+    })
+
+    it('should generate correct CSS', () => {
+      expect(sheet.toString()).to.be(
+        '.a-2802939882 .b-attention-3645560457 {\n' +
+        '  float: left;\n' +
+        '}\n' +
+        '.b-attention-3645560457 {\n' +
+        '  color: red;\n' +
+        '}'
+      )
+    })
+  })
+
   describe('nesting conditionals in combination with extend plugin', () => {
     let sheet
     let localJss


### PR DESCRIPTION
In the current jss-nested release refs with '-' characters are not supported. This PR solves that limitation by enhancing the refRegExp to support valid css class names as refs. 